### PR TITLE
ENG-104148: Upgrade urllib3 to v2.6.0 to fix CVE-2025-66418

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests>=2.31.0
+urllib3>=2.6.0


### PR DESCRIPTION
## Summary

- Fixes **CVE-2025-66418** - High severity vulnerability (CVSS 8.9) in urllib3
- Pins `urllib3>=2.6.0` in requirements.txt to ensure patched version is installed

## Vulnerability Details

- **CVE**: CVE-2025-66418
- **Severity**: HIGH (CVSS 8.9)
- **Affected Package**: `urllib3` versions >=1.24,<2.6.0
- **Impact**: Unbounded decompression chain allowing malicious servers to cause high CPU usage and massive memory allocation
- **Fix**: urllib3 v2.6.0 limits decompression chain links to 5

## Changes

- Added explicit `urllib3>=2.6.0` dependency to `requirements.txt`

## Jira Ticket

[ENG-104148](https://armorcodeinc.atlassian.net/browse/ENG-104148)

## Test Plan

- [ ] Docker build succeeds with updated requirements
- [ ] Application functions correctly with urllib3 v2.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ENG-104148]: https://armorcodeinc.atlassian.net/browse/ENG-104148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ